### PR TITLE
Ensuring 100% animation completion

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -127,8 +127,24 @@ const easyScroll = ({
         } else {
           requestAnimationFrame(scrollOnNextTick);
         }
-      } else if (onAnimationCompleteCallback) {
-        onAnimationCompleteCallback();
+      } else {
+        // Ensure 100% scroll completion
+        const scrollAmt = totalScroll;
+        const scrollToForFinalTick = (
+          isToBottomOrToRight ? 
+          scrollAmt + initialScrollPosition : 
+          totalScroll - scrollAmt
+        );
+        if (isWindow) {
+          const xScrollTo = isHorizontalDirection ? scrollToForFinalTick : 0;
+          const yScrollTo = isHorizontalDirection ? 0 : scrollToForFinalTick;
+          window.scrollTo(xScrollTo, yScrollTo);
+        } else {
+          scrollableDomEle[scrollDirectionProp] = scrollToForFinalTick;        
+        }
+        // Run callback
+        if (onAnimationCompleteCallback)
+          onAnimationCompleteCallback();
       }
     }
   }


### PR DESCRIPTION
When scrolling too fast the animation may not have reached the its final position by the moment `runTime` equals or exceeds duration. I've added a few lines that ensure the final position is accurately set on the final tick, right before calling `onAnimationCompleteCallback`.